### PR TITLE
修复因"目录名称无效"而导致的重新索引失败

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -216,7 +216,14 @@ namespace Wox.Plugin.Program.Programs
                 {
                     foreach (var suffix in suffixes)
                     {
-                        files.AddRange(Directory.EnumerateFiles(currentDirectory, $"*.{suffix}", SearchOption.TopDirectoryOnly));
+                        try
+                        {
+                            files.AddRange(Directory.EnumerateFiles(currentDirectory, $"*.{suffix}", SearchOption.TopDirectoryOnly));
+                        }
+                        catch (DirectoryNotFoundException e)
+                        {
+                            continue;
+                        }
                     }
                 }
                 catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)


### PR DESCRIPTION
新建一个PR到dev
fix #1975